### PR TITLE
GP-1824: Make preferred language configurable

### DIFF
--- a/settings/uimods.setting.php
+++ b/settings/uimods.setting.php
@@ -27,4 +27,15 @@ return array(
     'is_contact' => 0,
     'description' => 'Stored information on custom fields',
   ),
+  'at_greenpeace_uimods_preferred_language' => array(
+    'group_name' => 'GP UIMods',
+    'group' => 'at_greenpeace_uimods',
+    'name' => 'at_greenpeace_uimods_preferred_language',
+    'type' => 'string',
+    'default' => 'de_DE',
+    'add' => '4.6',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Default preferred language for new contacts',
+  ),
  );

--- a/uimods.php
+++ b/uimods.php
@@ -20,8 +20,19 @@ require_once 'uimods.civix.php';
 function uimods_civicrm_pre($op, $objectName, $id, &$params) {
   // GP-815: for newly created contacts:
   if ($op == 'create' && !$id && ($objectName == 'Individual' || $objectName == 'Organization')) {
-    // ...set preferred language to German
-    $params['preferred_language'] = 'de_DE';
+    $preferredLanguage = civicrm_api3('Setting', 'GetValue', [
+      'name' => 'at_greenpeace_uimods_preferred_language',
+      'group' => 'GP UIMods'
+    ]);
+    if (empty($preferredLanguage)) {
+      $default = civicrm_api3('Setting', 'getdefaults', [
+        'name' => 'at_greenpeace_uimods_preferred_language',
+        'group' => 'GP UIMods'
+      ]);
+      $preferredLanguage = reset($default['values'])['at_greenpeace_uimods_preferred_language'];
+    }
+    // ...set preferred language to configured language
+    $params['preferred_language'] = $preferredLanguage;
   }
 }
 


### PR DESCRIPTION
Use a configuration variable for `preferred_language` when creating new contacts.