### PR TITLE
GP-14437: Remove our custom ico for 'on hold' emails

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.5.1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.24</ver>
+    <ver>5.38</ver>
   </compatibility>
   <comments></comments>
   <civix>

--- a/js/handle_icons.js
+++ b/js/handle_icons.js
@@ -1,11 +1,4 @@
 cj(document).ready(function () {
-
-  var html = '' +
-    '<span ' +
-    'class="fa fa-exclamation" ' +
-    'style="float:right;height:16px;padding:0 1px;font-size:14px;color:#CB0001;" ' +
-    'title="' + ts('Email on hold - generally due to bouncing.') + '"' +
-    '></span>';
   var supportIcon = '' +
     '<span ' +
     'class="fa fa-medkit" ' +
@@ -19,12 +12,6 @@ cj(document).ready(function () {
     cj("#crm-email-content .crm-summary-row .crm-label").each(function (i, obj) {
       if (typeof CRM.vars['uimods']['email'][i + 1] == 'undefined') {
         return;
-      }
-      if (CRM.vars['uimods']['email'][i + 1]['on_hold'] !== '0' && CRM.vars['uimods']['privacy']['do_not_email'] !== '0') {
-        cj(obj).append(html);
-      } else if (CRM.vars['uimods']['email'][i + 1]['on_hold'] !== '0') {
-        cj(obj).find('.icon').remove();
-        cj(obj).append(html);
       }
       if (CRM.vars['uimods']['email'][i + 1]['location_type_id'] == CRM.vars['uimods']['supportId']) {
         cj(obj).append(supportIcon);


### PR DESCRIPTION
- Removed our custom ico for 'on hold' emails.
 It prevents icon duplicate because civi provides own ico in new version.
- Updated compatibility to 5.38.