### PR TITLE
GP-30260 GreenpeaceMessageTemplate.send API

### DIFF
--- a/api/v3/GreenpeaceMessageTemplate/Send.php
+++ b/api/v3/GreenpeaceMessageTemplate/Send.php
@@ -17,8 +17,8 @@ function _civicrm_api3_greenpeace_message_template_send_spec(&$spec) {
     'api.required' => 1
   ];
 
-  $spec['to_emails'] = [
-    'name'         => 'to_emails',
+  $spec['to_email'] = [
+    'name'         => 'to_email',
     'title'        => 'To Emails (comma separated list)',
     'type'         => CRM_Utils_Type::T_STRING,
     'api.required' => 1
@@ -45,15 +45,14 @@ function civicrm_api3_greenpeace_message_template_send($params) {
   ];
 
   try {
-    $emails = explode(",", $params['to_emails']);
+    $emails = explode(",", $params['to_email']);
     foreach ($emails as $email) {
       if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
         $return_values['invalid'][] = $email;
       } else {
-        $message_template = civicrm_api3('MessageTemplate', 'send', [
-          'id' => $params['id'],
-          'to_email' => $email
-        ]);
+        // override single email in params
+        $params['to_email'] = $email;
+        civicrm_api3('MessageTemplate', 'send', $params);
         $return_values['valid'][] = $email;
       }
     }

--- a/api/v3/GreenpeaceMessageTemplate/Send.php
+++ b/api/v3/GreenpeaceMessageTemplate/Send.php
@@ -1,0 +1,65 @@
+<?php
+use CRM_Uimods_ExtensionUtil as E;
+
+/**
+ * GreenpeaceMessageTemplate.Send API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/api-architecture/
+ */
+function _civicrm_api3_greenpeace_message_template_send_spec(&$spec) {
+  $spec['id'] = [
+    'name'         => 'id',
+    'title'        => 'MessageTemplate ID',
+    'type'         => CRM_Utils_Type::T_INT,
+    'api.required' => 1
+  ];
+
+  $spec['to_emails'] = [
+    'name'         => 'to_emails',
+    'title'        => 'To Emails (comma separated list)',
+    'type'         => CRM_Utils_Type::T_STRING,
+    'api.required' => 1
+  ];
+}
+
+/**
+ * GreenpeaceMessageTemplate.Send API
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ *
+ * @throws API_Exception
+ */
+function civicrm_api3_greenpeace_message_template_send($params) {
+
+  $return_values = [
+    'valid' => [],
+    'invalid' => []
+  ];
+
+  try {
+    $emails = explode(",", $params['to_emails']);
+    foreach ($emails as $email) {
+      if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $return_values['invalid'][] = $email;
+      } else {
+        $message_template = civicrm_api3('MessageTemplate', 'send', [
+          'id' => $params['id'],
+          'to_email' => $email
+        ]);
+        $return_values['valid'][] = $email;
+      }
+    }
+  } catch (CiviCRM_API3_Exception $e) {
+    throw new API_Exception('MessageTemplate send failed: ', $e->getMessage());
+  }
+
+  return civicrm_api3_create_success($return_values, $params, 'MessageTemplate', 'send');
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/tests/phpunit/api/v3/GreenpeaceMessageTemplate/SendTest.php
+++ b/tests/phpunit/api/v3/GreenpeaceMessageTemplate/SendTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * GreenpeaceMessageTemplate.Send API Test Case
+ * This is a generic test class implemented with PHPUnit.
+ * @group headless
+ */
+class api_v3_GreenpeaceMessageTemplate_SendTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+  use \Civi\Test\Api3TestTrait;
+
+  /**
+   * Set up for headless tests.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * The setup() method is executed before the test is executed (optional).
+   */
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * The tearDown() method is executed after the test was executed (optional)
+   * This can be used for cleanup.
+   */
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Test invalid email.
+   */
+  public function testInvalidEmail() {
+    $result = civicrm_api3('GreenpeaceMessageTemplate', 'send', [
+      'id' => 1,
+      'to_emails' => 'abc123'
+    ]);
+    $this->assertEquals('abc123', $result['values']['invalid'][0]);
+  }
+
+  /**
+   * Test valid email.
+   */
+  public function testValidEmail() {
+    $result = civicrm_api3('GreenpeaceMessageTemplate', 'send', [
+      'id' => 1,
+      'to_emails' => 'abc123@test.com'
+    ]);
+    $this->assertEquals('abc123@test.com', $result['values']['valid'][0]);
+  }
+
+  /**
+   * Test valid emails (comma separated list).
+   */
+  public function testValidEmails() {
+    $emails = [
+      'abc123@test.com',
+      'xyz123@test.com',
+      'test@gmail.com'
+    ];
+    $result = civicrm_api3('GreenpeaceMessageTemplate', 'send', [
+      'id' => 1,
+      'to_emails' => implode(',', $emails)
+    ]);
+    $this->assertEquals($emails[0], $result['values']['valid'][0]);
+    $this->assertEquals($emails[1], $result['values']['valid'][1]);
+    $this->assertEquals($emails[2], $result['values']['valid'][2]);
+  }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,63 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/uimods.civix.php
+++ b/uimods.civix.php
@@ -221,8 +221,7 @@ function _uimods_civix_upgrader() {
  * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
- * for backward compatibility of extension code that uses it.
+ * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
  *
  * @param string $dir base dir
  * @param string $pattern , glob pattern, eg "*.txt"
@@ -230,7 +229,32 @@ function _uimods_civix_upgrader() {
  * @return array
  */
 function _uimods_civix_find_files($dir, $pattern) {
-  return CRM_Utils_File::findFiles($dir, $pattern);
+  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
+    return CRM_Utils_File::findFiles($dir, $pattern);
+  }
+
+  $todos = [$dir];
+  $result = [];
+  while (!empty($todos)) {
+    $subdir = array_shift($todos);
+    foreach (_uimods_civix_glob("$subdir/$pattern") as $match) {
+      if (!is_dir($match)) {
+        $result[] = $match;
+      }
+    }
+    if ($dh = opendir($subdir)) {
+      while (FALSE !== ($entry = readdir($dh))) {
+        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
+        if ($entry[0] == '.') {
+        }
+        elseif (is_dir($path)) {
+          $todos[] = $path;
+        }
+      }
+      closedir($dh);
+    }
+  }
+  return $result;
 }
 
 /**


### PR DESCRIPTION
Wrapper for MessageTemplate.send -> GreenpeaceMessageTemplate.send API accepts two params:
id (message template id)
to_emails (comma separated list of emails)