### PR TITLE
Add help file to fix warnings at the contribution form.

### DIFF
--- a/templates/CRM/Contribute/Page/UimodsTab.hlp
+++ b/templates/CRM/Contribute/Page/UimodsTab.hlp
@@ -1,0 +1,89 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{htxt id="id-contrib_source-title"}
+  {ts}Source{/ts}
+{/htxt}
+{htxt id="id-contrib_source"}
+{ts}Optional identifier for the contribution source (campaign name, event, mailer, etc.).{/ts}
+{/htxt}
+
+{htxt id="id-total_amount-title"}
+  {ts}Total Amount{/ts}
+{/htxt}
+{htxt id="id-total_amount"}
+{ts 1='target="_blank" href="https://civicrm.org/extensions/line-item-editor"'}You are not allowed to change the total amount as it will lead to incorrect line item entries. You can either delete or recreate or install <a %1>Line Item Editor</a>.{/ts}
+{/htxt}
+
+{htxt id="id-financial_type-title"}
+  {ts}Financial Type{/ts}
+{/htxt}
+{htxt id="id-financial_type"}
+{ts}Select the appropriate financial type for this transaction.{/ts}
+{/htxt}
+
+{htxt id="payment_instrument_id-title"}
+  {ts}Payment Method{/ts}
+{/htxt}
+{htxt id="payment_instrument_id"}
+  <p>
+    {ts}Choose the method by which this transaction was paid.{/ts}
+  </p><p>
+    {ts}Note: if the correct payment method is not listed here (e.g. for in-kind donations) ask your administrator to add a new option to this list.{/ts}
+  </p>
+
+{/htxt}
+
+{htxt id="id-trans_id-title"}
+  {ts}Transaction ID{/ts}
+{/htxt}
+{htxt id="id-trans_id"}
+{ts}Unique payment ID for this transaction. The Payment Processor's transaction ID will be automatically stored here on online contributions.{/ts} {ts}For offline contributions you can record a bank transfer ID or other identifier if applicable.{/ts}
+{/htxt}
+
+{htxt id="id-soft_credit-title"}
+  {ts}Soft Credit{/ts}
+{/htxt}
+{htxt id="id-soft_credit"}
+<p>
+{ts}Use to indicate that a contact has a relationship with the actual donor and / or was indirectly responsible for the contribution. For example, if one family member makes a large contribution - it is often useful to record a Soft Credit for the other family member(s). You can record a soft credit while adding or editing a contribution record from this tab.{/ts}
+</p>
+<p>
+{ts}When a contribution is made via a Personal Campaign Page, a soft credit for that contribution is automatically assigned to the contact who created the Personal Campaign Page.{/ts}
+</p>
+{/htxt}
+
+{htxt id="id-pcp-title"}
+  {ts}Personal Campaign Page{/ts}
+{/htxt}
+{htxt id="id-pcp"}
+<p>
+{ts}Use this section to indicate that the contribution came in via a constituent's Personal Campaign Page (PCP), OR should be credited to that PCP post facto.{/ts}
+</p>
+<p>
+{ts}When contributions are made via a Personal Campaign Page a soft credit (of type 'Personal Campaign Page') is automatically created and assigned to the 'owner' of the the Personal Campaign Page.{/ts}
+</p>
+{/htxt}
+
+{htxt id="adjust-payment-amount-title"}
+  {ts}Payment Amount{/ts}
+{/htxt}
+{htxt id="adjust-payment-amount"}
+{ts}If you enter a payment which is different than the scheduled amount, choose one of these options:{/ts}
+<p>
+<strong>{ts}Adjust Pledge Payment Schedule{/ts}</strong><br />
+{ts}The next scheduled payment will be adjusted up or down to make up the difference.{/ts}<br />
+<em>{ts}Example: If you enter a payment of 60 when the scheduled amount is 50, the next scheduled payment is adjusted to 40.{/ts}</em>
+</p>
+<p>
+<strong>{ts}Adjust Total Pledge Amount{/ts}</strong><br />
+{ts}The total amount of the pledge will be adjusted up or down to make up the difference. The payment schedule ( amounts / dates for future pending pledge payments ) is not changed.{/ts}<br />
+<em>{ts}Example: If you enter a payment of 60 when the scheduled amount is 50, the total pledge amount will be increased by 10.{/ts}</em>
+</p>
+{/htxt}


### PR DESCRIPTION
It fixes warnigngs at the contribution form, and fix help icons near fields at the form.
Help file the is got from civi core. 
The file the same in old version of CiviCRM and new version. 