### PR TITLE
GP-33731: Fix BankAccount resolver to work in core activity form.

### DIFF
--- a/CRM/Uimods/Tools/BankAccount.php
+++ b/CRM/Uimods/Tools/BankAccount.php
@@ -26,8 +26,7 @@ class CRM_Uimods_Tools_BankAccount {
    * passing the build_form hook
    */
   public static function renderForm($formName, &$form) {
-    if ($formName == 'CRM_Contribute_Form_ContributionView'
-       || $formName == 'CRM_Activity_Form_Activity') {
+    if ($formName == 'CRM_Contribute_Form_ContributionView') {
       $viewCustomData = $form->get_template_vars('viewCustomData');
       // $contact_id = self::getContactID($form);
       $modified = FALSE;


### PR DESCRIPTION
Issue:
The `view Activity` form has the same logic of replcing is in [`contract`](https://github.com/greenpeace-cee/de.systopia.contract/blob/ff531e75b17237f92030c856d9628565dcdbfc12/contract.php#L227) extension and `uimods` extension. 
The double logic of replacing makes issue: `Bank Account` field is empty.
How it does:
First extension get value(it is `bank account id`) from `Bank Account` field and replcae it to IBAN.
Second extension do the same, but `Bank Account` field already replaced. 
And extension cannot find any IBAN, that's why  `Bank Account` field is empty.

Solution:
Remove bank account replacing(from id to IBAN) at view core Activity form at the `uimods` extension. 
