### PR TITLE
GP-36305 Add inbound SMS hooks

### DIFF
--- a/CRM/Uimods/SMS/Listener.php
+++ b/CRM/Uimods/SMS/Listener.php
@@ -1,0 +1,99 @@
+<?php
+
+use Civi\Api4\Contact;
+use Civi\Api4\Phone;
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Event\PreEvent;
+
+class CRM_Uimods_Sms_Listener {
+
+  public static array $newPhones = [];
+
+  /**
+   * Process Phone entity pre events
+   *
+   * @param \Civi\Core\Event\PreEvent $event
+   */
+  public static function pre(PreEvent $event) {
+    if ($event->action != 'create' || $event->entity != 'Phone') {
+      return;
+    }
+    if (empty($event->params['phone'])) {
+      return;
+    }
+    if (!in_array($event->params['phone'], self::$newPhones)) {
+      return;
+    }
+    // this is a new phone. should we update location_type_id?
+    if (!empty(\Civi::settings()->get('at_greenpeace_uimods_sms_default_location_type_id'))) {
+      // default location type for new phones is set, overwrite it
+      $event->params['location_type_id'] = \Civi::settings()->get('at_greenpeace_uimods_sms_default_location_type_id');
+    }
+    $key = array_search($event->params['phone'], self::$newPhones);
+    unset(self::$newPhones[$key]);
+  }
+
+  /**
+   * Process inboundSMS events
+   *
+   * This roughly reimplements the contact matcher in CRM_SMS_Provider:::processInbound,
+   * with some changes:
+   *  - uses APIv4
+   *  - matching contacts are explicitly ordered by lowest contact_id first
+   *  - the phone number is used as the display_name, rather than adding a fake
+   *    <phone>@mobile.sms email
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   *
+   * @throws \Exception
+   */
+  public static function inboundSMS(GenericHookEvent $event) {
+    $message = $event->message;
+    $message->fromContactID = self::getOrCreateContact($message->from);
+    $session = CRM_Core_Session::singleton();
+    $userId = $session->get('userID');
+    if (empty($userId)) {
+      $session->set('userID', $message->fromContactID);
+    }
+    $message->toContactID = self::getOrCreateContact($message->to);
+  }
+
+  public static function getOrCreateContact($phone) {
+    $contact = Phone::get()
+      ->addSelect('contact_id')
+      ->addWhere('phone', '=', $phone)
+      ->addWhere('contact_id.is_deleted', '=', FALSE)
+      ->addOrderBy('contact_id', 'ASC')
+      ->setCheckPermissions(FALSE)
+      ->execute()
+      ->first();
+
+    if (!empty($contact)) {
+      // matched to existing contact
+      return $contact['contact_id'];
+    }
+    else {
+      if (\Civi::settings()->get('at_greenpeace_uimods_sms_discard_unknown_sender')) {
+        // we don't really have a good way to "discard" SMS from this hook
+        // other than to just ... exit.
+        CRM_Utils_System::civiExit();
+      }
+      // we want to process inbound SMS from unknown numbers. create a contact
+      // using the phone number as the display name
+
+      // remember phone for pre hook
+      self::$newPhones[] = $phone;
+      // create a new contact
+      $contact = Contact::create(FALSE)
+        ->addValue('display_name', $phone)
+        ->addChain('Phone', Phone::create()
+          ->addValue('contact_id', '$id')
+          ->addValue('phone', $phone)
+        )
+        ->execute()
+        ->single();
+      return $contact['id'];
+    }
+  }
+
+}

--- a/settings/uimods.setting.php
+++ b/settings/uimods.setting.php
@@ -15,8 +15,8 @@
 /*
 * Settings metadata file
 */
-return array(
-  'at_greenpeace_uimods_config' => array(
+return [
+  'at_greenpeace_uimods_config' => [
     'group_name' => 'GP UIMods',
     'group' => 'at_greenpeace_uimods',
     'name' => 'at_greenpeace_uimods_config',
@@ -26,8 +26,8 @@ return array(
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => 'Stored information on custom fields',
-  ),
-  'at_greenpeace_uimods_preferred_language' => array(
+  ],
+  'at_greenpeace_uimods_preferred_language' => [
     'group_name' => 'GP UIMods',
     'group' => 'at_greenpeace_uimods',
     'name' => 'at_greenpeace_uimods_preferred_language',
@@ -37,8 +37,8 @@ return array(
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => 'Default preferred language for new contacts',
-  ),
-  'at_greenpeace_uimods_token_sql_task_id' => array(
+  ],
+  'at_greenpeace_uimods_token_sql_task_id' => [
     'group_name' => 'GP UIMods',
     'group' => 'at_greenpeace_uimods',
     'name' => 'at_greenpeace_uimods_token_sql_task_id',
@@ -48,5 +48,27 @@ return array(
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => 'SQL Task called to generate contact tokens',
-  ),
- );
+  ],
+  'at_greenpeace_uimods_sms_default_location_type_id' => [
+    'group_name' => 'GP UIMods',
+    'group' => 'at_greenpeace_uimods',
+    'name' => 'at_greenpeace_uimods_sms_default_location_type_id',
+    'type' => 'integer',
+    'default' => NULL,
+    'add' => '4.6',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Default location type for new phone numbers generated from inbound SMS',
+  ],
+  'at_greenpeace_uimods_sms_discard_unknown_sender' => [
+    'group_name' => 'GP UIMods',
+    'group' => 'at_greenpeace_uimods',
+    'name' => 'at_greenpeace_uimods_sms_discard_unknown_sender',
+    'type' => 'Boolean',
+    'default' => FALSE,
+    'add' => '4.6',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => 'Discard SMS from unknown sender?',
+  ],
+ ];

--- a/uimods.php
+++ b/uimods.php
@@ -207,6 +207,17 @@ function uimods_civicrm_pageRun( &$page ) {
  */
 function uimods_civicrm_config(&$config) {
   _uimods_civix_civicrm_config($config);
+  // register replacement hooks and let them run as early as possible
+  Civi::dispatcher()->addListener(
+    'hook_civicrm_pre',
+    'CRM_Uimods_Sms_Listener::pre',
+    PHP_INT_MAX - 1
+  );
+  Civi::dispatcher()->addListener(
+    'hook_civicrm_inboundSMS',
+    'CRM_Uimods_Sms_Listener::inboundSMS',
+    PHP_INT_MAX - 1
+  );
 }
 
 /**


### PR DESCRIPTION
This imports business logic that was previously included in the websms extension but was too specific for our use-case. This also introduces a new configuration option to determine whether SMS from unknown senders should be discarded or imported as phone numbers with a specific location type.