### PR TITLE
GP-47465 Prevent email receipts and confirmations from being sent

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,84 @@
+name: "Run unit tests"
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+  pull_request:
+
+env:
+  CIVI_CI_CIVICRM: ${{ vars.CIVI_CI_CIVICRM || '["master"]' }}
+  CIVI_CI_MYSQL: ${{ vars.CIVI_CI_MYSQL || '["8.0"]' }}
+  CIVI_CI_OS: ${{ vars.CIVI_CI_OS || '["ubuntu-22.04"]' }}
+  CIVI_CI_PHP: ${{ vars.CIVI_CI_PHP || '["8.1"]' }}
+  CIVI_CI_BUILD_TYPE: ${{ vars.CIVI_CI_BUILD_TYPE || '["drupal-clean"]' }}
+  CIVI_CI_EXCLUDES: ${{ vars.CIVI_CI_EXCLUDES || '' }}
+
+jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setup-matrix.outputs.matrix }}
+    steps:
+      - id: setup-matrix
+        uses: druzsan/setup-matrix@v2
+        with:
+          matrix: |
+            civicrm: ${{ env.CIVI_CI_CIVICRM }}
+            mysql: ${{ env.CIVI_CI_MYSQL }}
+            os: ${{ env.CIVI_CI_OS }}
+            php: ${{ env.CIVI_CI_PHP }}
+            build-type: ${{ env.CIVI_CI_BUILD_TYPE }}
+            exclude: ${{ env.CIVI_CI_EXCLUDES }}
+
+  run-tests:
+    needs: setup-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    runs-on: "${{ matrix.os }}"
+
+    services:
+      mysql:
+        image: "mysql:${{ matrix.mysql }}"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        ports:
+          - "3306:3306"
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval="10s"
+          --health-timeout="5s"
+          --health-retries="3"
+
+    steps:
+      - id: clone-repo
+        name: "Clone the repository"
+        uses: "actions/checkout@v4"
+        with:
+          path: "at.greenpeace.uimods"
+      - id: build-ci
+        uses: greenpeace-cee/civi-ci@main
+        with:
+          extension: at.greenpeace.uimods
+          civicrm: ${{ matrix.civicrm }}
+          php: ${{ matrix.php }}
+          build-type: ${{ matrix.build-type }}
+      - id: install-extension
+        name: "Install Extension"
+        env:
+          EXT_DIR: ${{ steps.build-ci.outputs.ext-dir }}
+        run: |
+          PATH="/home/runner/buildkit/bin:$PATH"
+          cd "$EXT_DIR"
+          cp -R "$GITHUB_WORKSPACE/at.greenpeace.uimods" "$EXT_DIR/at.greenpeace.uimods"
+          cv en at.greenpeace.uimods
+      - id: run-tests
+        name: "Run Tests"
+        env:
+          EXT_DIR: ${{ steps.build-ci.outputs.ext-dir }}
+        run: |
+          PATH="/home/runner/buildkit/bin:$PATH"
+          cd "$EXT_DIR/at.greenpeace.uimods"
+          CIVICRM_UF="UnitTests" phpunit9

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.phpunit.result.cache

--- a/CRM/Uimods/Config.php
+++ b/CRM/Uimods/Config.php
@@ -260,7 +260,13 @@ class CRM_Uimods_Config {
    */
   public static function getExtendedDemographicsGroup() {
     if (self::$extended_demographics_group == NULL) {
-      self::$extended_demographics_group = civicrm_api3('CustomGroup', 'getsingle', array('name' => 'additional_demographics'));
+      try {
+        self::$extended_demographics_group = civicrm_api3('CustomGroup', 'getsingle', array('name' => 'additional_demographics'));
+      } catch (CRM_Core_Exception $e) {
+        Civi::log()->error('Unable to find CustomGroup "additional_demographics": ' . $e->getMessage());
+        return NULL;
+      }
+
     }
     return self::$extended_demographics_group;
   }

--- a/CRM/Uimods/Tools/EmailReceipt.php
+++ b/CRM/Uimods/Tools/EmailReceipt.php
@@ -1,0 +1,34 @@
+<?php
+
+class CRM_Uimods_Tools_EmailReceipt {
+
+  /**
+   * Disable and uncheck email receipt/notification checkboxes in various forms
+   *
+   * @param $formName
+   * @param \CRM_Core_Form $form
+   *
+   * @return void
+   */
+  public static function process_buildForm($formName, CRM_Core_Form &$form) {
+    $fields = [];
+    switch ($formName) {
+      case 'CRM_Event_Form_Participant':
+        $fields[] = 'send_receipt';
+        $fields[] = 'is_notify';
+        break;
+
+      case 'CRM_Contribute_Form_Contribution':
+        $fields[] = 'is_email_receipt';
+        break;
+    }
+    foreach ($fields as $field) {
+      if ($form->elementExists($field)) {
+        $formElement = $form->getElement($field);
+        $formElement->setValue(FALSE);
+        $formElement->setAttribute('disabled', TRUE);
+      }
+    }
+  }
+
+}

--- a/CRM/Uimods/Tools/MoneyFields.php
+++ b/CRM/Uimods/Tools/MoneyFields.php
@@ -48,7 +48,7 @@ class CRM_Uimods_Tools_MoneyFields {
           if ($form->elementExists($fieldName)) {
             $element = $form->getElement($fieldName);
             $value = $element->getValue();
-            $cleanValue = str_replace($monetaryDecimalPoint, "", $value);
+            $cleanValue = str_replace($monetaryDecimalPoint, "", $value ?? '');
             $element->setValue($cleanValue);
           }
         }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Greenpeace UI Modifications
+
+[![Run unit tests](https://github.com/greenpeace-cee/at.greenpeace.uimods/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/greenpeace-cee/at.greenpeace.uimods/actions/workflows/unit-tests.yml)
+
+
+The extension is licensed under [AGPL-3.0](LICENSE.txt).
+
+## Installation
+
+Learn more about installing CiviCRM extensions in the [CiviCRM Sysadmin Guide](https://docs.civicrm.org/sysadmin/en/latest/customize/extensions/).
+
+## Setup

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./</directory>
-    </whitelist>
-  </filter>
   <listeners>
     <listener class="Civi\Test\CiviTestListener">
       <arguments/>

--- a/settings/uimods.setting.php
+++ b/settings/uimods.setting.php
@@ -1,27 +1,14 @@
 <?php
-/*-------------------------------------------------------+
-| Greenpeace UI Modifications                            |
-| Copyright (C) 2017 SYSTOPIA                            |
-+--------------------------------------------------------+
-| This program is released as free software under the    |
-| Affero GPL license. You can redistribute it and/or     |
-| modify it under the terms of this license which you    |
-| can read by viewing the included agpl.txt or online    |
-| at www.gnu.org/licenses/agpl.html. Removal of this     |
-| copyright header is strictly prohibited without        |
-| written permission from the original author(s).        |
-+--------------------------------------------------------*/
 
-/*
-* Settings metadata file
-*/
+use CRM_Uimods_ExtensionUtil as E;
+
 return [
   'at_greenpeace_uimods_config' => [
     'group_name' => 'GP UIMods',
     'group' => 'at_greenpeace_uimods',
     'name' => 'at_greenpeace_uimods_config',
     'type' => 'Array',
-    'default' => array(),
+    'default' => [],
     'add' => '4.6',
     'is_domain' => 1,
     'is_contact' => 0,
@@ -81,5 +68,21 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => 'Group name, which uses for filter at "activity_assignees" field.',
+  ],
+  'allowed_email_workflows' => [
+    'name'        => 'allowed_email_workflows',
+    'type'        => 'Array',
+    'html_type'   => 'text',
+    'default'     => [
+      '/^password_reset$/',
+      '/^test_preview$/',
+    ],
+    'add'         => '1.0',
+    'title'       => E::ts('Allowed Email Workflows'),
+    'description' => E::ts(
+      'Allowlist of email workflows (message templates) in RegEx format which are allowed to be used for outbound emails.'
+           . 'Attempting to send workflows not listed here will raise an Exception to prevent accidental email communication to supporters.'),
+    'is_domain'   => 1,
+    'is_contact'  => 0,
   ],
  ];

--- a/tests/phpunit/api/v3/GreenpeaceMessageTemplate/SendTest.php
+++ b/tests/phpunit/api/v3/GreenpeaceMessageTemplate/SendTest.php
@@ -28,7 +28,7 @@ class api_v3_GreenpeaceMessageTemplate_SendTest extends \PHPUnit\Framework\TestC
   /**
    * The setup() method is executed before the test is executed (optional).
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
   }
 
@@ -36,7 +36,7 @@ class api_v3_GreenpeaceMessageTemplate_SendTest extends \PHPUnit\Framework\TestC
    * The tearDown() method is executed after the test was executed (optional)
    * This can be used for cleanup.
    */
-  public function tearDown() {
+  public function tearDown(): void {
     parent::tearDown();
   }
 

--- a/uimods.php
+++ b/uimods.php
@@ -427,7 +427,7 @@ function uimods_civicrm_alterAPIPermissions($entity, $action, &$params, &$permis
  * @throws \Exception
  */
 function uimods_civicrm_alterMailParams(&$params, $context) {
-  if (!empty($params['workflow'])) {
+  if (!empty($params['workflow']) && $params['workflow'] != 'UNKNOWN') {
     foreach (Civi::settings()->get('allowed_email_workflows') ?? [] as $allowedWorkflow) {
       if (preg_match($allowedWorkflow, $params['workflow'])) {
         // workflow is allowed, continue


### PR DESCRIPTION
This adds two mechanisms that should prevent accidental emails from
being sent to supporters:
- In forms that have an "send email receipt/notification" checkbox, disable the checkbox and set it to unchecked
- In scenarios where emails are always sent with no UI option to prevent that, the `alterMailParams` hook is triggered at the time of sending.If we detect a workflow name that is not allowlisted via the `allowed_email_workflows` setting, throw an exception as a last resort.