### PR TITLE
GP-47328 Fix form error overflow issue in contact name form

### DIFF
--- a/css/contact-name-inline-edit.css
+++ b/css/contact-name-inline-edit.css
@@ -1,0 +1,5 @@
+#crm-contactname-content.crm-inline-edit.form:has(span.crm-error) {
+  overflow: visible !important;
+  height: auto !important;
+  max-height: none !important;
+}

--- a/uimods.php
+++ b/uimods.php
@@ -97,6 +97,12 @@ function uimods_civicrm_buildForm($formName, &$form) {
       if ($form->elementExists('activity_role')) {
         $form->setDefaults(['activity_role' => 0]);
       }
+      break;
+
+    case 'CRM_Contact_Form_Inline_ContactName':
+      // fix overflow issue for form errors
+      CRM_Core_Resources::singleton()->addStyleFile('at.greenpeace.uimods', 'css/contact-name-inline-edit.css');
+      break;
   }
 }
 


### PR DESCRIPTION
This fixes an issue where the inline contact name form overflows if error messages are present. This typically does not happen in core, but is possible due to custom validators added in `de.systopia.bpk`.

The underlying issue no longer exists in newer versions of core with riverlea.